### PR TITLE
GROUNDWORK-1675-result-statistics:  extend Nagios to provide queue stats

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -242,6 +242,7 @@ check_result    *check_result_list_tail = NULL;
 #else
 check_result    *check_result_list = NULL;
 #endif
+int check_result_list_length = 0;
 time_t max_check_result_file_age;
 
 check_stats     check_statistics[MAX_CHECK_STATS_TYPES];
@@ -2371,8 +2372,10 @@ void save_queued_check_results(void) {
 #ifdef USE_CHECK_RESULT_DOUBLE_LINKED_LIST
 	check_result_list_head = NULL;
 	check_result_list_tail = NULL;
+	check_result_list_length = 0;
 #else
 	check_result_list = NULL;
+	check_result_list_length = 0;
 #endif
 
 #ifdef USE_EVENT_BROKER
@@ -2782,6 +2785,7 @@ check_result *read_check_result_double_list(void) {
 		else {
 			check_result_list_head->prev = NULL;
 			}
+		--check_result_list_length;
 		}
 
 #ifdef USE_EVENT_BROKER
@@ -2806,6 +2810,7 @@ check_result *read_check_result(check_result **listp) {
 	if(*listp != NULL) {
 		first_cr = *listp;
 		*listp = (*listp)->next;
+		--check_result_list_length;
 		}
 
 #ifdef USE_EVENT_BROKER
@@ -2914,6 +2919,8 @@ int add_check_result_to_double_list(check_result *new_cr) {
 		last_cr->prev = new_cr;
 		}
 
+	++check_result_list_length;
+
 #ifdef USE_EVENT_BROKER
 	/* Relinquish the check result list mutex */
 	pthread_mutex_unlock(&check_result_list_lock);
@@ -2964,6 +2971,8 @@ int add_check_result_to_list(check_result **listp, check_result *new_cr) {
 		last_cr->next = new_cr;
 		}
 
+	++check_result_list_length;
+
 #ifdef USE_EVENT_BROKER
 	/* Relinquish the check result list mutex */
 	pthread_mutex_unlock(&check_result_list_lock);
@@ -2994,6 +3003,7 @@ int free_check_result_double_list(void){
 
 	check_result_list_head=NULL;
 	check_result_list_tail=NULL;
+	check_result_list_length = 0;
 
 #ifdef USE_EVENT_BROKER
 	/* Relinquish the check result list mutex */
@@ -3024,6 +3034,7 @@ int free_check_result_list(check_result **listp) {
 		}
 
 	*listp = NULL;
+	check_result_list_length = 0;
 
 #ifdef USE_EVENT_BROKER
 	/* Relinquish the check result list mutex */
@@ -3051,6 +3062,64 @@ int free_check_result(check_result *info)
 
 	return OK;
 }
+
+#ifdef USE_CHECK_RESULT_DOUBLE_LINKED_LIST
+struct check_result_list_stats get_check_result_double_list_statistics()
+{
+	struct check_result_list_stats check_result_list_statistics;
+
+#ifdef USE_EVENT_BROKER
+	/* Acquire the check result list mutex */
+	pthread_mutex_lock(&check_result_list_lock);
+#endif
+
+	check_result_list_statistics.list_length = check_result_list_length;
+	if (check_result_list_statistics.list_length > 0) {
+		check_result_list_statistics.first_item_finish_time = check_result_list_head->finish_time;
+		check_result_list_statistics. last_item_finish_time = check_result_list_tail->finish_time;
+	}
+
+#ifdef USE_EVENT_BROKER
+	/* Relinquish the check result list mutex */
+	pthread_mutex_unlock(&check_result_list_lock);
+#endif
+
+	return check_result_list_statistics;
+}
+#endif
+
+#ifndef USE_CHECK_RESULT_DOUBLE_LINKED_LIST
+struct check_result_list_stats get_check_result_list_statistics(check_result **listp)
+{
+	struct check_result_list_stats check_result_list_statistics;
+
+#ifdef USE_EVENT_BROKER
+	/* Acquire the check result list mutex */
+	pthread_mutex_lock(&check_result_list_lock);
+#endif
+
+	check_result_list_statistics.list_length = check_result_list_length;
+	if (check_result_list_statistics.list_length > 0) {
+		// We have in hand only a pointer to the head of the list.
+		//
+		// We are not about to spend a lot of time walking the entire list to find the tail,
+		// just to retrieve this one piece of information.  That would cause O(n) behavior
+		// in retrieving statistics when we really want just O(1) behavior.  Therefore, we
+		// fake it by simply replicating the timestamp of the item at the head of the list,
+		// which is the more important (oldest-timestamp) value anyway.  We accept that as
+		// a practical limitation of operating with only a single-linked list.
+		check_result_list_statistics.first_item_finish_time = (*listp)->finish_time;
+		check_result_list_statistics. last_item_finish_time = (*listp)->finish_time;
+	}
+
+#ifdef USE_EVENT_BROKER
+	/* Relinquish the check result list mutex */
+	pthread_mutex_unlock(&check_result_list_lock);
+#endif
+
+	return check_result_list_statistics;
+}
+#endif
 
 
 /******************************************************************/

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -519,15 +519,27 @@ int process_check_result_file(char *);
 int process_check_result(check_result *);
 
 #ifdef USE_CHECK_RESULT_DOUBLE_LINKED_LIST
+
 int add_check_result_to_double_list(check_result *new_cr);
 #define ADD_ONE_CHECK_RESULT(dummy_check_result_list_ptr, check_result_ptr) add_check_result_to_double_list(check_result_ptr)
+
 check_result *read_check_result_double_list(void);		/* reads a host/service check result from the list in memory */
 #define READ_ONE_CHECK_RESULT(dummy_check_result_list_ptr) read_check_result_double_list()
+
+extern struct check_result_list_stats get_check_result_double_list_statistics();
+#define GET_CHECK_RESULT_LIST_STATS(dummy_check_result_list_ptr) get_check_result_double_list_statistics()
+
 #else
+
 int add_check_result_to_list(check_result **, check_result *);
 #define ADD_ONE_CHECK_RESULT(check_result_list_ptr, check_result_ptr) add_check_result_to_list(check_result_list_ptr, check_result_ptr)
+
 check_result *read_check_result(check_result **);		/* reads a host/service check result from the list in memory */
 #define READ_ONE_CHECK_RESULT(check_result_list_ptr) read_check_result(check_result_list_ptr)
+
+extern struct check_result_list_stats get_check_result_list_statistics(check_result **);
+#define GET_CHECK_RESULT_LIST_STATS(check_result_list_ptr) get_check_result_list_statistics(check_result_list_ptr)
+
 #endif
 
 int delete_check_result_file(char *);

--- a/include/objects.h
+++ b/include/objects.h
@@ -182,6 +182,11 @@ typedef struct check_result {
 #endif
 	} check_result;
 
+struct check_result_list_stats {
+	int list_length;
+	struct timeval first_item_finish_time;
+	struct timeval  last_item_finish_time;
+};
 
 /* SCHED_INFO structure */
 typedef struct sched_info {


### PR DESCRIPTION
Modify our existing patches to Nagios that insert and remove items
from the check-result queue we use to pass data from Bronx to Nagios.
The effect is to efficiently keep track of how many items are in the
queue at any time.  Provide a means to safely retrieve that info and
some data about the items at either end of the queue, so an outside
agency can have some degree of observability as to processing latency.