### PR TITLE
GROUNDWORK-1711-tmp-directory:  don't change owner/perm on /tmp

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -288,7 +288,9 @@ install-unstripped:
 	$(MAKE) install-basic
 
 install-basic:
-	if [ '$(DESTDIR)$(TMPDIR)' != /tmp ]; then $(INSTALL) -m 755 $(INSTALL_OPTS) -d $(DESTDIR)$(TMPDIR); fi
+	if [ '$(DESTDIR)$(TMPDIR)' != /tmp -a '$(DESTDIR)$(TMPDIR)' != /var/tmp ]; then \
+	    $(INSTALL) -m 755 $(INSTALL_OPTS) -d $(DESTDIR)$(TMPDIR); \
+	fi
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LIBEXECDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)/archives

--- a/Makefile.in
+++ b/Makefile.in
@@ -288,7 +288,7 @@ install-unstripped:
 	$(MAKE) install-basic
 
 install-basic:
-	$(INSTALL) -m 755 $(INSTALL_OPTS) -d $(DESTDIR)$(TMPDIR)
+	if [ '$(DESTDIR)$(TMPDIR)' != /tmp ]; then $(INSTALL) -m 755 $(INSTALL_OPTS) -d $(DESTDIR)$(TMPDIR); fi
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LIBEXECDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(LOGDIR)/archives


### PR DESCRIPTION
In GW8, we use /tmp as the temp_path in Nagios, unlike in GW7 where we
used a different directory that would not already exist.  With the use
of /tmp, we don't want to change either its ownership or permissions.