### PR TITLE
GROUNDWORK-1718-add-broker-calls:  extend Nagios support for DataGeyser

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -1242,6 +1242,11 @@ int handle_async_service_check_result(service *svc, check_result *cr)
 
 	int new_last_hard_state	       = svc->last_hard_state;
 
+#if defined(USE_EVENT_BROKER) && defined(PASS_UNPROCESSED_STATES)
+	/* This one piece of data is saved away because service_is_passive() and service_is_active() modify this one field. */
+	int old_check_type = svc->check_type;
+#endif
+
 	if (cr->check_type == CHECK_TYPE_PASSIVE) {
 		if (service_is_passive(svc, cr) == FALSE) {
 			return ERROR;
@@ -1250,6 +1255,10 @@ int handle_async_service_check_result(service *svc, check_result *cr)
 	else {
 		service_is_active(svc);
 	}
+
+#if defined(USE_EVENT_BROKER) && defined(PASS_UNPROCESSED_STATES)
+	broker_service_data(NEBTYPE_SERVICECHECK_UNPROCESSED, NEBFLAG_NONE, NEBATTR_NONE, svc, old_check_type, NULL, cr);
+#endif
 
 	time(&current_time);
 	initialize_last_service_state_change_times(svc, hst);
@@ -2288,6 +2297,11 @@ int handle_async_host_check_result(host *hst, check_result *cr)
 
 	int new_last_hard_state	 = hst->last_hard_state;
 
+#if defined(USE_EVENT_BROKER) && defined(PASS_UNPROCESSED_STATES)
+	/* This one piece of data is saved away because host_is_passive() and host_is_active() modify this one field. */
+	int old_check_type = hst->check_type;
+#endif
+
 	if (cr->check_type == CHECK_TYPE_PASSIVE) {
 		if (host_is_passive(hst, cr) == FALSE) {
 			return ERROR;
@@ -2296,6 +2310,11 @@ int handle_async_host_check_result(host *hst, check_result *cr)
 	else  {
 		host_is_active(hst);
 	}
+
+#if defined(USE_EVENT_BROKER) && defined(PASS_UNPROCESSED_STATES)
+	broker_host_data(NEBTYPE_HOSTCHECK_UNPROCESSED, NEBFLAG_NONE, NEBATTR_NONE, hst, old_check_type, NULL, cr);
+#endif
+
 	time(&current_time);
 	initialize_last_host_state_change_times(hst);
 
@@ -3227,6 +3246,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 	if (raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Raw check command for host '%s' was NULL - aborting.\n", hst->name);
+		hst->latency = old_latency;
 		return ERROR;
 	}
 
@@ -3236,6 +3256,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 	if (processed_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Processed check command for host '%s' was NULL - aborting.\n", hst->name);
+		hst->latency = old_latency;
 		return ERROR;
 	}
 
@@ -3247,6 +3268,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		log_debug_info(DEBUGL_CHECKS, 0, "Failed to allocate checkresult struct\n");
 		clear_volatile_macros_r(&mac);
 		clear_host_macros_r(&mac);
+		hst->latency = old_latency;
 		return ERROR;
 	}
 	init_check_result(cr);

--- a/common/downtime.c
+++ b/common/downtime.c
@@ -603,7 +603,7 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 		/* decrement the downtime depth variable */
 		if(temp_downtime->type == HOST_DOWNTIME && hst->scheduled_downtime_depth > 0)
 			hst->scheduled_downtime_depth--;
-		else if (svc->scheduled_downtime_depth > 0)
+		else if (temp_downtime->type == SERVICE_DOWNTIME && svc->scheduled_downtime_depth > 0)
 			svc->scheduled_downtime_depth--;
 
 		if(temp_downtime->type == HOST_DOWNTIME && hst->scheduled_downtime_depth == 0) {

--- a/include/broker.h
+++ b/include/broker.h
@@ -97,6 +97,9 @@
 #define NEBTYPE_SERVICECHECK_RAW_START           702   /* NOT IMPLEMENTED */
 #define NEBTYPE_SERVICECHECK_RAW_END             703   /* NOT IMPLEMENTED */
 #define NEBTYPE_SERVICECHECK_ASYNC_PRECHECK      704
+#ifdef PASS_UNPROCESSED_STATES
+#define NEBTYPE_SERVICECHECK_UNPROCESSED         750   /* immediately before a service check result gets processed */
+#endif
 
 #define NEBTYPE_HOSTCHECK_INITIATE               800   /* a check of the route to the host has been initiated */
 #define NEBTYPE_HOSTCHECK_PROCESSED              801   /* the processed/final result of a host check */
@@ -104,6 +107,9 @@
 #define NEBTYPE_HOSTCHECK_RAW_END                803   /* a finished "raw" host check */
 #define NEBTYPE_HOSTCHECK_ASYNC_PRECHECK         804
 #define NEBTYPE_HOSTCHECK_SYNC_PRECHECK          805
+#ifdef PASS_UNPROCESSED_STATES
+#define NEBTYPE_HOSTCHECK_UNPROCESSED            850   /* immediately before a host check result gets processed */
+#endif
 
 #define NEBTYPE_COMMENT_ADD                      900
 #define NEBTYPE_COMMENT_DELETE                   901
@@ -186,6 +192,10 @@ void broker_timed_event(int, int, int, timed_event *, struct timeval *);
 void broker_log_data(int, int, int, char *, unsigned long, time_t, struct timeval *);
 int broker_event_handler(int, int, int, int, void *, int, int, struct timeval, struct timeval, double, int, int, int, char *, char *, char *, struct timeval *);
 void broker_system_command(int, int, int, struct timeval, struct timeval, double, int, int, int, char *, char *, struct timeval *);
+#ifdef PASS_UNPROCESSED_STATES
+void broker_host_data(int, int, int, host *, int, struct timeval *, check_result *);
+void broker_service_data(int, int, int, service *, int, struct timeval *, check_result *);
+#endif
 int broker_host_check(int, int, int, host *, int, int, int, struct timeval, struct timeval, char *, double, double, int, int, int, char *, char *, char *, char *, struct timeval *, check_result *);
 int broker_service_check(int, int, int, service *, int, struct timeval, struct timeval, char *, double, double, int, int, int, char *, struct timeval *, check_result *);
 void broker_comment_data(int, int, int, int, int, char *, char *, time_t, char *, char *, int, int, int, time_t, unsigned long, struct timeval *);


### PR DESCRIPTION
Add support within Nagios itself to provide a means for DataGeyser to see
the states of individual hosts and services right before check results
are applied to those objects.  DataGeyser can then cache that early
state and compare it to the state after the check results are applied,
to see which data items actually need to be sent downstream.

Also fix a few Nagios bugs we spotted while doing the analysis for the
changes related to DataGeyser.  These bugs relate to how downtime and
latency data is handled.  This bug fixes have been noted, and we will
eventually report them upstream (though the Nagios folks don't seem to
be paying attention to any bug reports in the last couple of years.)